### PR TITLE
readme: Instructions on installing with Guix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ To install it via [straight](https://github.com/radian-software/straight.el) wit
 (use-package verilog-ts-mode)
 ```
 
+### GUIX ###
+
+To install via [Guix](https://guix.gnu.org) use:
+
+``` shell
+$ guix install emacs-verilog-ts-mode
+```
+
+No need to manually install tree-sitter, it is pulled automatically.
+
 ### Tree-sitter grammar ###
 
 The package provides an interactive command to simplify the installation of the grammar:


### PR DESCRIPTION
This package just got merged [merged](https://codeberg.org/guix/guix/commit/70c8fe9ce0f8719a0e4b0863550e60ca314b9ac0) and is available now. 

Note that I'm using here `tree-sitter-systemverilog`, instead of `tree-sitter-verilog`.